### PR TITLE
Only set order value when specified.

### DIFF
--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -332,7 +332,15 @@ final class WP_Term_Order {
 	 */
 	public function add_term_order( $term_id = 0, $tt_id = 0, $taxonomy = '' ) {
 
-		// Bail if not updating order
+		/*
+		 * Bail if order info hasn't been POSTed, like when the "Quick Edit"
+		 * form is used to update a term.
+		 */
+		if ( ! isset( $_POST['order'] ) ) {
+			return;
+		}
+
+		// Sanitize the value.
 		$order = ! empty( $_POST['order'] )
 			? (int) $_POST['order']
 			: 0;


### PR DESCRIPTION
Hi John-

Same thing here. I noticed that when updating terms via the “Quick Edit” interface, the `$_POST` payload doesn’t include every meta field. So, the save routine is losing saved values when Quick Edit is used.

To duplicate, reorder some terms. Then, use "Quick Edit" on one of the terms in the middle. It will end up with an order of 0, and, on page refresh, be bumped to the top of the list.

Thanks for the great term plugins!