### PR TITLE
Only automatically order terms for supported taxonomies.

### DIFF
--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -146,6 +146,21 @@ final class WP_Term_Order {
 
 	/** Assets ****************************************************************/
 
+	public function taxonomy_supported( $taxonomy ) {
+
+		if ( is_array( $taxonomy ) ) {
+			foreach ( $taxonomy as $tax ) {
+				if ( ! in_array( $tax, $this->taxonomies ) ) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		return in_array( $taxonomy, $this->taxonomies );
+
+	}
+
 	/**
 	 * Enqueue quick-edit JS
 	 *
@@ -508,6 +523,10 @@ final class WP_Term_Order {
 	 * @return string
 	 */
 	public function get_terms_orderby( $orderby = 'name', $args = array() ) {
+
+		if ( ! $this->taxonomy_supported( $args['taxonomy'] ) ) {
+			return $orderby;
+		}
 
 		// Do not override if being manually controlled
 		if ( ! empty( $_GET['orderby'] ) && ! empty( $_GET['taxonomy'] ) ) {


### PR DESCRIPTION
Your following commit in the latest unreleased dev fixed supported for the `wp_term_order_get_taxonomies` filter, disabling admin ordering for taxonomies that had been removed via the filter:
https://github.com/stuttter/wp-term-order/commit/399d2b3ac2dd86324e3a75d103cf33817d60154d

However, removed taxonomies are still automatically ordered via the `get_terms_orderby` filter.

This commit only adjusts the order for supported taxonomies and leaves other taxonomies using their default order.

## Test:

Remove a taxonomy using the filter:

```
function my_wp_term_order_get_taxonomies( $taxonomies ) {
	unset($taxonomies['my_taxonomy'] );
	return $taxonomies;

}
add_filter( 'wp_term_order_get_taxonomies', 'my_wp_term_order_get_taxonomies' );
```

Currently editing the order is disabled in the admin, although the admin and front-end still both display by the custom order.

After apply this fix, the order will revert to the default values before the plugin filters them.