### PR TITLE
Add `wp_term_order_set_term_order` action.

### DIFF
--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -374,6 +374,8 @@ final class WP_Term_Order {
 			)
 		);
 
+		do_action( 'wp_term_order_set_term_order', $term_id, $taxonomy, $order );
+
 		// Maybe clean the term cache
 		if ( true === $clean_cache ) {
 			clean_term_cache( $term_id, $taxonomy );


### PR DESCRIPTION
Trigger an action when a term's order is updated.

This allows for integration with other plugins like WPML, so that term order could be synced across translations.