### PR TITLE
Use term order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WP Term Order
 
-Sort taxonomy terms, your way.
+Sort taxonomy terms. This is a adapted fork from JJJ by RamonFincken. This for uses the WP Core `term_order` column in the `terms` table, instead of creating a new colum in the `wp_term_taxonomy` table.
 
 WP Term Order allows users to order any visible category, tag, or taxonomy term numerically, providing a customized order for their taxonomy terms.
 
@@ -22,7 +22,7 @@ No. There are no new database tables with this plugin.
 
 ### Does this modify existing database tables?
 
-Yes. The `wp_term_taxonomy` table is altered, and an `order` column is added.
+No. It uses the WP Core `term_order` colum in the `terms` table
 
 ### Can I query and sort by `order`?
 
@@ -33,20 +33,15 @@ $terms = get_terms( 'category', array(
 	'depth'      => 1,
 	'number'     => 100,
 	'parent'     => 0,
-	'orderby'    => 'order', // <--- Looky looky!
+	'orderby'    => 'term_order', // <--- Looky looky!
 	'order'      => 'ASC',
 	'hide_empty' => false,
-
-	// Try the "wp-term-meta" plugin!
-	'meta_query' => array( array(
-		'key' => 'term_thumbnail'
-	) )
 ) );
 ```
 
 ### Where can I get support?
 
-The WordPress support forums: https://wordpress.org/support/plugin/wp-term-order/
+Github
 
 ### Can I contribute?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WP Term Order
 
-Sort taxonomy terms. This is a adapted fork from JJJ by RamonFincken. This fork uses the WP Core `term_order` column in the `terms` table, instead of creating a new colum in the `wp_term_taxonomy` table.
+Sort taxonomy terms. This is an adapted fork from JJJ by RamonFincken. This fork uses the WP Core `term_order` column in the `terms` table, instead of creating a new colum in the `wp_term_taxonomy` table.
 
 WP Term Order allows users to order any visible category, tag, or taxonomy term numerically, providing a customized order for their taxonomy terms.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WP Term Order
 
-Sort taxonomy terms. This is a adapted fork from JJJ by RamonFincken. This for uses the WP Core `term_order` column in the `terms` table, instead of creating a new colum in the `wp_term_taxonomy` table.
+Sort taxonomy terms. This is a adapted fork from JJJ by RamonFincken. This fork uses the WP Core `term_order` column in the `terms` table, instead of creating a new colum in the `wp_term_taxonomy` table.
 
 WP Term Order allows users to order any visible category, tag, or taxonomy term numerically, providing a customized order for their taxonomy terms.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,32 +1,19 @@
 === WP Term Order ===
-Contributors: johnjamesjacoby, stuttter
-Tags: taxonomy, term, order
+Contributors: johnjamesjacoby, stuttter, ramonfincken
+Tags: taxonomy, term, order, term_order
 Requires at least: 4.3
-Tested up to: 4.4
-Stable tag: 0.1.4
+Tested up to: 5.2.4
+Stable tag: 0.1.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9Q4F4EL5YJ62J
+Donate link: http://donate.ramonfincken.com
 
 == Description ==
 
-Sort taxonomy terms, your way.
+Sort taxonomy terms, your way. This fork uses the WP Core `term_order` column in the `terms` table, instead of creating a new colum in the `wp_term_taxonomy` table.
 
 WP Term Order allows users to order any visible category, tag, or taxonomy term numerically, providing a customized order for their taxonomies.
 
-= Also checkout =
-
-* [WP Chosen](https://wordpress.org/plugins/wp-chosen/ "Make long, unwieldy select boxes much more user-friendly.")
-* [WP Event Calendar](https://wordpress.org/plugins/wp-event-calendar/ "The best way to manage events in WordPress.")
-* [WP Term Meta](https://wordpress.org/plugins/wp-term-meta/ "Metadata, for taxonomy terms.")
-* [WP Term Authors](https://wordpress.org/plugins/wp-term-authors/ "Authors for categories, tags, and other taxonomy terms.")
-* [WP Term Colors](https://wordpress.org/plugins/wp-term-colors/ "Pretty colors for categories, tags, and other taxonomy terms.")
-* [WP Term Icons](https://wordpress.org/plugins/wp-term-icons/ "Pretty icons for categories, tags, and other taxonomy terms.")
-* [WP Term Visibility](https://wordpress.org/plugins/wp-term-visibility/ "Visibilities for categories, tags, and other taxonomy terms.")
-* [WP User Groups](https://wordpress.org/plugins/wp-user-groups/ "Group users together with taxonomies & terms.")
-* [WP User Activity](https://wordpress.org/plugins/wp-user-activity/ "The best way to log activity in WordPress.")
-* [WP User Avatars](https://wordpress.org/plugins/wp-user-avatars/ "Allow users to upload avatars or choose them from your media library.")
-* [WP User Profiles](https://wordpress.org/plugins/wp-user-profiles/ "A sophisticated way to edit users in WordPress.")
 
 == Screenshots ==
 
@@ -38,7 +25,7 @@ Download and install using the built in WordPress plugin installer.
 
 Activate in the "Plugins" area of your admin by clicking the "Activate" link.
 
-No further setup or configuration is necessary.
+No further setup or configuration is necessary, as long as your get_terms code uses 'orderby'    => 'term_order', 
 
 == Frequently Asked Questions ==
 
@@ -48,17 +35,22 @@ No. There are no new database tables with this plugin.
 
 = Does this modify existing database tables? =
 
-Yes. The `wp_term_taxonomy` table is altered, and an `order` column is added.
+No. It uses the WP Core `term_order` colum in the `terms` table
 
 = Where can I get support? =
 
-The WordPress support forums: https://wordpress.org/support/plugin/wp-term-order/
+Github
 
 = Where can I find documentation? =
 
 http://github.com/stuttter/wp-term-order/
 
 == Changelog ==
+
+= 0.1.5 =
+* Use Core term_order<br>
+* Pre-calculate the next order number<br>
+* Add some dev notices
 
 = 0.1.4 =
 * Fix order saving in non-fancy mode

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -64,9 +64,19 @@ final class WP_Term_Order {
 	public $taxonomies = array();
 
 	/**
-	 * @var boo Whether to use fancy ordering
+	 * @var bool Whether to use fancy ordering
 	 */
 	public $fancy = false;
+	
+	/**
+	 * @var bool Whether to show the column
+	 */
+	public $column = true;
+	
+	/**
+	 * @var bool Whether to use inline editing
+	 */
+	public $inline = true;
 
 	/**
 	 * Hook into queries, admin screens, and more!

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -66,7 +66,7 @@ final class WP_Term_Order {
 	/**
 	 * @var bool Whether to use fancy ordering
 	 */
-	public $fancy = false;
+	public $fancy = true;
 	
 	/**
 	 * @var bool Whether to show the column
@@ -90,7 +90,7 @@ final class WP_Term_Order {
 		$this->url      = plugin_dir_url( $this->file );
 		$this->path     = plugin_dir_path( $this->file );
 		$this->basename = plugin_basename( $this->file );
-		$this->fancy    = apply_filters( 'wp_fancy_term_order', false );
+		$this->fancy    = apply_filters( 'wp_fancy_term_order', true );
 		$this->column    = apply_filters( 'wp_fancy_term_order_column', true );
 		$this->inline    = apply_filters( 'wp_fancy_term_order_inline', true );
 

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -76,7 +76,7 @@ final class WP_Term_Order {
 	/**
 	 * @var bool Whether to use inline editing
 	 */
-	public $inline = true;
+	public $inline = false;
 
 	/**
 	 * Hook into queries, admin screens, and more!
@@ -91,11 +91,11 @@ final class WP_Term_Order {
 		$this->path     = plugin_dir_path( $this->file );
 		$this->basename = plugin_basename( $this->file );
 		$this->fancy    = apply_filters( 'wp_fancy_term_order', true );
-		$this->column    = apply_filters( 'wp_fancy_term_order_column', true );
-		$this->inline    = apply_filters( 'wp_fancy_term_order_inline', true );
+		$this->column    = apply_filters( 'wp_fancy_term_order_column', false );
+		$this->inline    = apply_filters( 'wp_fancy_term_order_inline', false );
 
 		// Queries
-		/// add_filter( 'get_terms_orderby', array( $this, 'get_terms_orderby' ), 10, 2 );
+		add_filter( 'get_terms_orderby', array( $this, 'get_terms_orderby' ), 10, 2 );
 		add_action( 'create_term',       array( $this, 'add_term_order'    ), 10, 3 );
 		add_action( 'edit_term',         array( $this, 'add_term_order'    ), 10, 3 );
 
@@ -296,7 +296,7 @@ final class WP_Term_Order {
 	 * @return array
 	 */
 	public function add_column_header( $columns = array() ) {
-		$columns['order'] = __( 'Order', 'wp-term-order' );
+		$columns['term_order'] = __( 'Order', 'wp-term-order' );
 
 		return $columns;
 	}
@@ -315,7 +315,7 @@ final class WP_Term_Order {
 	public function add_column_value( $empty = '', $custom_column = '', $term_id = 0 ) {
 	    
 		// Bail if no taxonomy passed or not on the `order` column
-		if ( empty( $_REQUEST['taxonomy'] ) || ( 'order' !== $custom_column ) || ! empty( $empty ) ) {
+		if ( empty( $_REQUEST['taxonomy'] ) || ( 'term_order' !== $custom_column ) || ! empty( $empty ) ) {
 			return;
 		}
 
@@ -332,7 +332,7 @@ final class WP_Term_Order {
 	 * @return array
 	 */
 	public function sortable_columns( $columns = array() ) {
-		$columns['order'] = 'order';
+		$columns['term_order'] = 'term_order';
 		return $columns;
 	}
 
@@ -538,8 +538,8 @@ final class WP_Term_Order {
 		}
 
 		// Maybe force `orderby`
-		if ( empty( $args['orderby'] ) || empty( $orderby ) || ( 'order' === $args['orderby'] ) || in_array( $orderby, array( 'name', 't.name' ) ) ) {
-			$orderby = 'tt.order';
+		if ( empty( $args['orderby'] ) || empty( $orderby ) || ( 'term_order' === $args['orderby'] ) || in_array( $orderby, array( 'name', 't.name' ) ) ) {
+			$orderby = 't.term_order ';
 		} elseif ( 't.name' === $orderby ) {
 			$orderby = 'tt.order, t.name';
 		}
@@ -681,7 +681,7 @@ final class WP_Term_Order {
 			'hide_empty' => false,
 			'exclude'    => $excluded
 		) );
-
+		
 		// Loop through siblings and update terms
 		foreach ( $siblings as $sibling ) {
 


### PR DESCRIPTION
[FEATURE] use the WP Core `term_order` column in the `terms` table, instead of creating a new colum in the `wp_term_taxonomy` table