### PR TITLE
Fix: Make Non-Static Method Not Static; Globalize `WP_Term_Order`

### DIFF
--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -457,7 +457,7 @@ final class WP_Term_Order {
 	 *
 	 * @since 0.1.0
 	 */
-	public static function term_order_add_form_field() {
+	public function term_order_add_form_field() {
 		?>
 
 		<div class="form-field form-required">
@@ -790,6 +790,8 @@ endif;
  * @since 0.1.0
  */
 function _wp_term_order() {
-	new WP_Term_Order();
+	global $wp_term_order;
+
+	$wp_term_order = new WP_Term_Order();
 }
 add_action( 'init', '_wp_term_order', 99 );


### PR DESCRIPTION
## Summary

### 1. Make Non-Static Method Not Static

- The `WP_Term_Order::term_order_add_form_field()` method is declared as a static method, but only ever used in a non-static object context.
- This PR removes the unnecessary `static` method from that method declaration.

### 2. Globalize `WP_Term_Order`

- WP Term Order [has hook callback methods that cannot be unhooked](https://github.com/stuttter/wp-term-order/blob/master/wp-term-order.php#L106) via `remove_action()`. This is bad practice for a WordPress plugin or theme, and should be fixed. 
- A few different fixes are possible; one example is to implement a singleton design pattern for the `WP_Term_Order` class.
- But to keep things simple, I've just made the single existing object (created on an `init` hook callback) a global variable: `global $wp_term_order`.
- This global can then be referenced by `remove_action()` calls, without otherwise affecting any existing plugin functionality.