### PR TITLE
issue-36 - Various security improvements:

### DIFF
--- a/js/reorder.js
+++ b/js/reorder.js
@@ -124,23 +124,14 @@ sortable_terms_table.sortable( {
  */
 function term_order_update_callback( response, post ) {
 
-	// Default values
-	var error   = false,
-		changes = {},
-		new_pos = {};
-
-	// Catch errors
-	try {
-		changes = JSON.parse( response ),
-		new_pos = changes.new_pos;
-		error   = ( 'success' !== post );
-
-	} catch ( e ) {
-		error = true;
+	// Check if term has children (special case that requires page reload)
+	if ( response && response.data && 'children' === response.data.message ) {
+		window.location.reload();
+		return;
 	}
 
-	// Bail on early error
-	if ( true === error ) {
+	// Handle errors or missing response
+	if ( ! response || ! response.success ) {
 		sortable_terms_table
 			.hide()
 			.sortable( 'cancel' )
@@ -153,11 +144,9 @@ function term_order_update_callback( response, post ) {
 		return;
 	}
 
-	// Bail if term has children
-	if ( 'children' === response ) {
-		window.location.reload();
-		return;
-	}
+	// Extract data from successful response
+	var changes = response.data || {},
+		new_pos = changes.new_pos || {};
 
 	// Empty out order texts
 	for ( var key in new_pos ) {

--- a/js/reorder.js
+++ b/js/reorder.js
@@ -1,4 +1,4 @@
-/* global inlineEditTax, ajaxurl */
+/* global inlineEditTax, ajaxurl, wpTermOrder */
 
 var sortable_terms_table = jQuery( '.wp-list-table tbody' ),
 	taxonomy             = jQuery( 'form input[name="taxonomy"]' ).val(),
@@ -106,6 +106,7 @@ sortable_terms_table.sortable( {
 		// Go do the sorting stuff via ajax
 		jQuery.post( ajaxurl, {
 			action: 'reordering_terms',
+			nonce:  wpTermOrder.nonce,
 			id:     termid,
 			previd: prevtermid,
 			nextid: nexttermid,
@@ -175,7 +176,8 @@ function term_order_update_callback( response, post ) {
 	// Maybe repost the next change
 	if ( changes.next ) {
 		jQuery.post( ajaxurl, {
-			action:  'reordering_terms',
+			action:   'reordering_terms',
+			nonce:    wpTermOrder.nonce,
 			id:       changes.next['id'],
 			previd:   changes.next['previd'],
 			nextid:   changes.next['nextid'],

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors:      johnjamesjacoby, stuttter
 Tags:              taxonomy, term, order
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9Q4F4EL5YJ62J
-Requires at least: 4.3
-Tested up to:      6.5
-Stable tag:        2.1.0
+Requires at least: 5.3
+Requires PHP:      7.0
+Tested up to:      7.0
+Stable tag:        2.2.0
 
 == Description ==
 
@@ -58,9 +58,11 @@ http://github.com/stuttter/wp-term-order/
 
 == Changelog ==
 
+= 2.2.0 =
+* Fix CSRF. Thank you Nabil Irawan.
+
 = 2.1.0 =
 * PHP8 support
-* 
 
 = 2.0.0 =
 * Migrate existing order data to term meta on upgrade

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -36,7 +36,7 @@ final class WP_Term_Order {
 	/**
 	 * @var string Database version
 	 */
-	public $db_version = 202602070001;
+	public $db_version = 202602070003;
 
 	/**
 	 * @var string Database version
@@ -1070,7 +1070,7 @@ final class WP_Term_Order {
 				! isset( $_POST['nextid'] )
 			)
 		) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => 'Invalid request data' ) );
 		}
 
 		// Bail if prev && next ID are not numeric
@@ -1079,7 +1079,7 @@ final class WP_Term_Order {
 			&&
 			! is_numeric( $_POST['nextid'] )
 		) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => 'Invalid position data' ) );
 		}
 
 		// Sanitize
@@ -1091,18 +1091,18 @@ final class WP_Term_Order {
 
 		// Bail if taxonomy does not exist
 		if ( empty( $tax ) || ! $this->taxonomy_supported( $tax ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => 'Invalid taxonomy' ) );
 		}
 
 		// Bail if current user cannot assign term
 		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => 'Permission denied' ) );
 		}
 
 		// Bail if term cannot be found
 		$term = get_term( $term_id, $taxonomy );
 		if ( empty( $term ) || is_wp_error( $term ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => 'Term not found' ) );
 		}
 
 		// Sanitize positions
@@ -1159,7 +1159,7 @@ final class WP_Term_Order {
 
 		// Bail if error
 		if ( is_wp_error( $siblings ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => 'Failed to get siblings' ) );
 		}
 
 		// Loop through siblings and update terms
@@ -1256,15 +1256,14 @@ final class WP_Term_Order {
 			) );
 
 			if ( ! empty( $children ) && ! is_wp_error( $children ) ) {
-				wp_die( 'children' );
+				wp_send_json_error( array( 'message' => 'children' ) );
 			}
 		}
 
 		// Add to return value
 		$retval->new_pos = $new_pos;
 
-		// Send return value as JSON
-		wp_json_encode( $retval );
+		wp_send_json_success( $retval );
 	}
 }
 endif;

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -1070,7 +1070,7 @@ final class WP_Term_Order {
 				! isset( $_POST['nextid'] )
 			)
 		) {
-			wp_send_json_error( array( 'message' => 'Invalid request data' ) );
+			wp_send_json_error( array( 'message' => esc_html__( 'Invalid request data', 'wp-term-order' ) ) );
 		}
 
 		// Bail if prev && next ID are not numeric
@@ -1079,7 +1079,7 @@ final class WP_Term_Order {
 			&&
 			! is_numeric( $_POST['nextid'] )
 		) {
-			wp_send_json_error( array( 'message' => 'Invalid position data' ) );
+			wp_send_json_error( array( 'message' => esc_html__( 'Invalid position data', 'wp-term-order' ) ) );
 		}
 
 		// Sanitize
@@ -1091,18 +1091,18 @@ final class WP_Term_Order {
 
 		// Bail if taxonomy does not exist or is not supported
 		if ( empty( $tax ) || ! $this->taxonomy_supported( $taxonomy ) ) {
-			wp_die( -1 );
+			wp_send_json_error( array( 'message' => esc_html__( 'Invalid taxonomy', 'wp-term-order' ) ) );
 		}
 
 		// Bail if current user cannot assign term
 		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			wp_send_json_error( array( 'message' => 'Permission denied' ) );
+			wp_send_json_error( array( 'message' => esc_html__( 'Permission denied', 'wp-term-order' ) ) );
 		}
 
 		// Bail if term cannot be found
 		$term = get_term( $term_id, $taxonomy );
 		if ( empty( $term ) || is_wp_error( $term ) ) {
-			wp_send_json_error( array( 'message' => 'Term not found' ) );
+			wp_send_json_error( array( 'message' => esc_html__( 'Term not found', 'wp-term-order' ) ) );
 		}
 
 		// Sanitize positions
@@ -1159,7 +1159,7 @@ final class WP_Term_Order {
 
 		// Bail if error
 		if ( is_wp_error( $siblings ) ) {
-			wp_send_json_error( array( 'message' => 'Failed to get siblings' ) );
+			wp_send_json_error( array( 'message' => esc_html__( 'Failed to get siblings', 'wp-term-order' ) ) );
 		}
 
 		// Loop through siblings and update terms

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -1147,7 +1147,8 @@ final class WP_Term_Order {
 		}
 
 		// Get term siblings for relative ordering
-		$siblings = get_terms( $taxonomy, array(
+		$siblings = get_terms( array(
+			'taxonomy'   => $taxonomy,
 			'depth'      => 1,
 			'number'     => 100,
 			'parent'     => $parent_id,
@@ -1175,17 +1176,15 @@ final class WP_Term_Order {
 			if ( $nextid === (int) $sibling->term_id ) {
 				$this->set_term_order( $term->term_id, $taxonomy, $start, true );
 
-				$ancestors = get_ancestors( $term->term_id, $taxonomy, 'taxonomy' );
+				$term_ancestors = get_ancestors( $term->term_id, $taxonomy, 'taxonomy' );
 
 				$new_pos[ $term->term_id ] = array(
 					'order'  => $start,
 					'parent' => $parent_id,
-					'depth'  => count( $ancestors ),
+					'depth'  => count( $term_ancestors ),
 				);
 
 				$start++;
-			} else {
-				$ancestors = array();
 			}
 
 			// Get the term order, either from object or meta
@@ -1203,10 +1202,12 @@ final class WP_Term_Order {
 				$this->set_term_order( $sibling->term_id, $taxonomy, $start, true );
 			}
 
+			$sibling_ancestors = get_ancestors( $sibling->term_id, $taxonomy, 'taxonomy' );
+
 			$new_pos[ $sibling->term_id ] = array(
 				'order'  => $start,
 				'parent' => $parent_id,
-				'depth'  => count( $ancestors )
+				'depth'  => count( $sibling_ancestors )
 			);
 
 			$start++;
@@ -1214,17 +1215,15 @@ final class WP_Term_Order {
 			if ( empty( $nextid ) && ( $previd === (int) $sibling->term_id ) ) {
 				$this->set_term_order( $term->term_id, $taxonomy, $start, true );
 
-				$ancestors = get_ancestors( $term->term_id, $taxonomy, 'taxonomy' );
+				$term_ancestors = get_ancestors( $term->term_id, $taxonomy, 'taxonomy' );
 
 				$new_pos[ $term->term_id ] = array(
 					'order'  => $start,
 					'parent' => $parent_id,
-					'depth'  => count( $ancestors ),
+					'depth'  => count( $term_ancestors ),
 				);
 
 				$start++;
-			} else {
-				$ancestors = array();
 			}
 		}
 
@@ -1245,7 +1244,8 @@ final class WP_Term_Order {
 		if ( empty( $retval->next ) ) {
 
 			// If the moved term has children, refresh the page for UI reasons
-			$children = get_terms( $taxonomy, array(
+			$children = get_terms( array(
+				'taxonomy'   => $taxonomy,
 				'number'     => 1,
 				'depth'      => 1,
 				'orderby'    => 'order',

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -1089,8 +1089,8 @@ final class WP_Term_Order {
 		// Attempt to get the taxonomy
 		$tax = get_taxonomy( $taxonomy );
 
-		// Bail if taxonomy does not exist
-		if ( empty( $tax ) || ! $this->taxonomy_supported( $tax ) ) {
+		// Bail if taxonomy does not exist or is not supported
+		if ( empty( $tax ) || ! $this->taxonomy_supported( $taxonomy ) ) {
 			wp_die( -1 );
 		}
 

--- a/wp-term-order.php
+++ b/wp-term-order.php
@@ -89,7 +89,7 @@ final class WP_Term_Order {
 	public $term_clauses = array();
 
 	/**
-	 * @var array Term query clauses
+	 * @var array Meta query clauses
 	 */
 	public $meta_clauses = array();
 
@@ -224,7 +224,7 @@ final class WP_Term_Order {
 	 */
 	public function taxonomy_supported( $taxonomy = array() ) {
 
-		// Defaut return value
+		// Default return value
 		$retval = true;
 
 		if ( is_string( $taxonomy ) ) {
@@ -257,7 +257,7 @@ final class WP_Term_Order {
 	 */
 	public function taxonomy_override_orderby_supported( $taxonomy = array() ) {
 
-		// Defaut return value
+		// Default return value
 		$retval = $this->taxonomy_supported( $taxonomy );
 
 		// Filter & return
@@ -622,7 +622,7 @@ final class WP_Term_Order {
 	 */
 	public function get_term_order( $term_id = 0 ) {
 
-		// Use false
+		// Start with no value
 		$retval = false;
 
 		// Use term order if set and strategy allows
@@ -1130,7 +1130,7 @@ final class WP_Term_Order {
 		// If the next term's parent isn't the same as our parent, we need more info
 		} elseif ( $next_term_parent !== $parent_id ) {
 			$prev_term_parent = $previd
-				? wp_get_term_taxonomy_parent_id( $nextid, $taxonomy )
+				? wp_get_term_taxonomy_parent_id( $previd, $taxonomy )
 				: false;
 
 			// If the previous term is not our parent now, set it


### PR DESCRIPTION
- Add nonce check to prevent CSRF
- Prefer wp_die() over die()
- Prefer wp_json_encode() over json_encode()
- Use is_wp_error() in some places
- Adjust capability checks from edit_terms to edit_term and allow core WordPress to do the hard work via map_meta_cap
- Validate POSTed data in ajax_reordering_terms()
- Escape output in term_order_edit_form_field()
- Split enqueues up into register & localize hooks
- Bump various header infos to reasonable versions
- Bump plugin & db versions to latest
- Remove donate link